### PR TITLE
Disallow kit switching while in combat 1-3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 
 # Plugin Jars
 plugins/*.jar
+
+.idea

--- a/config/plugins/FortressWars/settings.yml
+++ b/config/plugins/FortressWars/settings.yml
@@ -29,6 +29,16 @@ settings:
   #  medium: 10
   #  high: 15
 
+  # Killstreaks
+  killstreaks:
+    enabled: true
+    killsPerLevel: 5
+    glowingDurationFromLevelIncrease: 60
+
+  # Combat
+  combat:
+    enforceOutOfCombatKitSwitching: true
+
   # Leaderboard settings
   leaderboards:
     frequencyTicks: 18000


### PR DESCRIPTION
disallow player from switching kits while in combat with a bollian toggle is settings.yml 